### PR TITLE
展示模型名追加tags (#951)

### DIFF
--- a/src/pandora/bots/legacy.py
+++ b/src/pandora/bots/legacy.py
@@ -464,7 +464,8 @@ class ChatBot:
         for idx, item in enumerate(models):
             number = str(idx + 1)
             choices.append(number)
-            Console.info('  {}.\t{} - {}'.format(number, item['title'], item['description']))
+            Console.info('  {}.\t{} - {} - {}'.format(number, item['title'], item['description'],
+                                                      '|'.join(item['tags'])))
 
         Console.warn('  r.\tRefresh model list')
 


### PR DESCRIPTION
原来格式化的结果可能存在同名model的情况，让用户无法分别model的区别和含义